### PR TITLE
idiomatic executable module style

### DIFF
--- a/druid.py
+++ b/druid.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 from __future__ import unicode_literals
 
 import sys
@@ -190,4 +192,5 @@ def main():
     crow.close()
     exit()
 
-main()
+if __name__ == '__main__':
+  main()


### PR DESCRIPTION
"executable modules" are a common pattern in Python. This change adopts the standard style which allows a module to be executed directly if it is the main source file otherwise behave as a normal module if being imported.

In addition a shebang line was added which should allow the script to be directly executed on macOS and Linux machines.
 
https://wiki.python.org/moin/ExecutableModules