### PR TITLE
patch prompt_toolkit to use spaces for tabs

### DIFF
--- a/druid.py
+++ b/druid.py
@@ -14,9 +14,13 @@ from prompt_toolkit.document import Document
 from prompt_toolkit.key_binding import KeyBindings
 from prompt_toolkit.layout.containers import VSplit, HSplit, Window, WindowAlign
 from prompt_toolkit.layout.layout import Layout
+from prompt_toolkit.layout.screen import Char
 from prompt_toolkit.styles import Style
 from prompt_toolkit.widgets import TextArea
 from prompt_toolkit.layout.controls import FormattedTextControl
+
+# monkey patch to fix https://github.com/monome/druid/issues/8
+Char.display_mappings['\t'] = '  '
 
 
 druid_intro = "//// druid. q to quit. h for help\n\n"


### PR DESCRIPTION
Fixes #8 

The [problem](https://github.com/prompt-toolkit/python-prompt-toolkit/issues/556) is that prompt_toolkit replaces tabs with `^I`, [here](https://github.com/prompt-toolkit/python-prompt-toolkit/blob/1e4b44e090088310f211357869555bc0decf1b09/prompt_toolkit/layout/screen.py#L50). This replaces this with two spaces instead. It has to be two spaces because this is the same width as `^I`, otherwise the linked issue thread indicates prompt_toolkit won't calculate character widths correctly.