### PR TITLE
bulk run/flash setup & longer delays

### DIFF
--- a/crowlib.py
+++ b/crowlib.py
@@ -27,25 +27,30 @@ def writelines( writer, file ):
         lua = d.readlines()
         for line in lua:
             writer( line.encode() ) # convert text to bytes
-            time.sleep(0.001) # fix os x crash?
+            time.sleep(0.002) # fix os x crash?
 
 def upload( writer, printer, file ):
     printer(" uploading "+file+"\n\r")
-    writer(bytes("^^k", 'utf-8'))
-    time.sleep(0.4) # wait for restart
     writer(bytes("^^s", 'utf-8'))
     time.sleep(0.2) # wait for allocation
     writelines( writer, file )
-    time.sleep(0.2) # wait for upload to complete
-    writer(bytes("^^e", 'utf-8'))
-    time.sleep(0.2) # wait for flash write
-    writer(bytes("init()\n\r", 'utf-8'))
+    time.sleep(0.4) # wait for upload to complete
+    writer(bytes("^^w", 'utf-8'))
 
 def execute( writer, printer, file ):
     printer(" running "+file+"\n\r")
-    writer(bytes("```", 'utf-8'))
+    writer(bytes("^^s", 'utf-8'))
+    time.sleep(0.2) # wait for allocation
     writelines( writer, file )
-    time.sleep(0.1)
-    writer(bytes("```", 'utf-8'))
-    time.sleep(0.1)
-    writer(bytes("init()\n\r", 'utf-8'))
+    time.sleep(0.2)
+    writer(bytes("^^e", 'utf-8'))
+
+# leaving this here for 'run a code chunk'
+#def execute( writer, printer, file ):
+#    printer(" running "+file+"\n\r")
+#    writer(bytes("```", 'utf-8'))
+#    writelines( writer, file )
+#    time.sleep(0.1)
+#    writer(bytes("```", 'utf-8'))
+#    time.sleep(0.1)
+#    writer(bytes("init()\n\r", 'utf-8'))

--- a/crowlib.py
+++ b/crowlib.py
@@ -34,7 +34,7 @@ def upload( writer, printer, file ):
     writer(bytes("^^s", 'utf-8'))
     time.sleep(0.2) # wait for allocation
     writelines( writer, file )
-    time.sleep(0.4) # wait for upload to complete
+    time.sleep(0.01) # wait for upload to complete
     writer(bytes("^^w", 'utf-8'))
 
 def execute( writer, printer, file ):
@@ -42,7 +42,7 @@ def execute( writer, printer, file ):
     writer(bytes("^^s", 'utf-8'))
     time.sleep(0.2) # wait for allocation
     writelines( writer, file )
-    time.sleep(0.2)
+    time.sleep(0.01)
     writer(bytes("^^e", 'utf-8'))
 
 # leaving this here for 'run a code chunk'


### PR DESCRIPTION
**REQUIRES crow-v1.0.0+**

Uses a far simplified upload/execute sequence (see https://github.com/monome/crow/pull/193).

Increased delays between-lines when uploading a file (2ms per line), and decreased delays at end of upload as crow handles the cleanup by itself.

DO NOT MERGE until we post the official crow 1.0.0