### PR TITLE
Restructure to normal python package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,10 +51,8 @@ Module.symvers
 Mkfile.old
 dkms.conf
 
-Lib/
-Scripts/
+build/
+dist/
 __pycache__/
 *.log
-pip-selfcheck.json
-pyvenv.cfg
 *~

--- a/README.md
+++ b/README.md
@@ -1,45 +1,31 @@
 # druid
 
-a basic repl for crow with some utilities
+A basic REPL for crow with some utilities
 
-## setup
+## Setup
 
-- requires python 3.5+
-  - windows & osx: https://www.python.org/downloads/
-  - linux: `sudo apt-get install python3 python3-pip`
-- requires pyserial, asyncio, and prompt_toolkit. install & run with:
+Requirements:
+- Python 3.5+
+  - Windows & OS X: https://www.python.org/downloads/
+  - Linux: `sudo apt-get install python3 python3-pip` or equivalent
+- `pip` and `setuptools`
+- `pyserial` and `prompt_toolkit`
 
-note: you might want `python` and `pip` instead of `python3` and `pip3`
-depending on your platform. if `python3` is not found, check that you have 
-python >= 3.5 with`python --version`.
+Note: you might need to use `python` and `pip` instead of `python3` and `pip3` depending on your platform. If `python3` is not found, check that you have python >= 3.5 with `python --version`.
 
-install and run:
+Install and run:
 ```bash
-pip3 install -r requirements.txt
-python3 druid.py
+# Ensure setuptools is up to date
+pip3 install --upgrade setuptools
+# Install druid
+pip3 install monome-druid
+# Run druid :)
+druid
 ```
 
-to avoid conflicts with other python applications on your system,
-you can run in a virtualenv instead of installing dependencies
-globally:
-```bash
-python3 -m venv .
+## Druid
 
-# windows
-source Scripts/activate  # need to do this each time you run a new shell
-
-# other
-source bin/activate  # need to do this each time you run a new shell
-
-pip install -r requirements.txt
-python druid.py
-```
-
-## druid
-
-```
-python3 druid.py
-```
+Start by running `druid`
 
 - type q (enter) to quit.
 - type h (enter) for a list of special commands.
@@ -48,10 +34,10 @@ python3 druid.py
 - will reconnect to crow after a disconnect / restart
 - scrollable console history
 
-example:
+Example:
 
 ```
-t@nav: ~/druid $ python3 druid.py
+druid
 //// druid. q to quit. h for help
 
 > x=6
@@ -64,36 +50,37 @@ t@nav: ~/druid $ python3 druid.py
 > q
 ```
 
-execute a lua script and enter the REPL from the command line:
+Execute a lua script and enter the REPL from the command line:
 ```
-python3 druid.py examples/test-2.lua
+druid examples/test-2.lua
 ```
 
-diagnostic logs are written to druid.log
+Diagnostic logs are written to `druid.log`.
 
-## upload
+## Upload
 
 ```
 python3 upload.py examples/test-2.lua
 ```
 
-uploads the provided lua file to crow & stores it in flash to be executed on boot.
+Uploads the provided lua file to crow & stores it in flash to be executed on boot.
 
-## download
+## Download
 
 ```
 python3 download.py
 ```
 
-prints to screen. copy to file by:
+Prints to screen.
+Copy to file by running:
 
 ```
 python3 download.py > feathers.lua
 ```
 
-## examples
+## Examples
 
-druid comes with a bunch of example scripts to help introduce crow's syntax, and spur your imagination with some zany ideas. Here's the list with a brief description of each (most scripts have a longer description including the assignment of ins and outs at the top of the script):
+Druid comes with a bunch of example scripts to help introduce crow's syntax, and spur your imagination with some zany ideas. Here's the list with a brief description of each (most scripts have a longer description including the assignment of ins and outs at the top of the script):
 
 - `boids.lua`: four simulated birds that fly around your input
 - `booleanlogic.lua`: logic gates determined by two input gates

--- a/download.py
+++ b/download.py
@@ -1,4 +1,6 @@
-import crowlib
+#!/usr/bin/env python3
+
+from druid import crowlib
 
 
 def main():
@@ -13,6 +15,5 @@ def main():
 
     crow.close()
     exit()
-
 
 main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,0 @@
-asyncio==3.4.3
-prompt-toolkit==2.0.10
-pyserial==3.4
-six==1.12.0
-wcwidth==0.1.7

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python3
+from setuptools import setup, find_namespace_packages
+
+# Read the contents of the readme to publish it to PyPI
+with open("README.md") as readme:
+    long_description = readme.read()
+
+setup(
+    name="monome-druid",
+    version="0.1.1",
+    description="Terminal interface for crow",
+    long_description=long_description,
+    long_description_content_type="text/markdown",
+    url="https://github.com/monome/druid",
+    author="monome",
+    author_email="bcrabtree@monome.org",
+    classifiers=[
+        "Programming Language :: Python :: 3",
+        "License :: OSI Approved :: GNU General Public License v3 (GPLv3)",
+        "Operating System :: OS Independent",
+    ],
+    packages=find_namespace_packages("src"),
+    package_dir={"": "src"},
+    include_package_data=True,
+    python_requires=">=3.5",
+    install_requires=[
+        "prompt-toolkit>=2.0.10",
+        "pyserial>=3.4",
+    ],
+    extras_require={
+        "test": [
+            "pylint",
+        ]
+    },
+    entry_points={
+        "console_scripts": [
+            "druid=druid.main:main",
+        ],
+    },
+)

--- a/setup.sh
+++ b/setup.sh
@@ -1,7 +1,0 @@
-set -ex
-python -m venv .
-pip install -r requirements.txt
-set +x
-echo "ready. run:"
-echo "  source Scripts/activate"
-echo "in this folder before running druid when you've opened a new shell"

--- a/src/druid/crowlib.py
+++ b/src/druid/crowlib.py
@@ -1,10 +1,11 @@
 import logging
-import serial
-import serial.tools.list_ports
 import time
 
-logger = logging.getLogger(__name__)
+import serial
+import serial.tools.list_ports
 
+
+logger = logging.getLogger(__name__)
 
 def connect():
     port = ""
@@ -22,7 +23,6 @@ def connect():
         logger.error("could not open comport {}".format(port), e)
         raise ValueError("can't open serial port")
 
-
 def reconnect():
     try:
         c = crow_connect()
@@ -30,7 +30,6 @@ def reconnect():
         return c
     except ValueError as err:
         myprint(" <lost connection>")
-
 
 def writelines(writer, file):
     with open(file) as d:
@@ -47,7 +46,6 @@ def upload(writer, printer, file):
     time.sleep(0.1)  # wait for upload to complete
     writer(bytes("^^w", 'utf-8'))
 
-
 def execute(writer, printer, file):
     printer(" running "+file+"\n\r")
     writer(bytes("^^s", 'utf-8'))
@@ -55,7 +53,6 @@ def execute(writer, printer, file):
     writelines(writer, file)
     time.sleep(0.01)
     writer(bytes("^^e", 'utf-8'))
-
 
 # leaving this here for 'run a code chunk'
 #def execute( writer, printer, file ):

--- a/src/druid/main.py
+++ b/src/druid/main.py
@@ -1,10 +1,5 @@
-#!/usr/bin/env python3
-
-from __future__ import unicode_literals
-
-import logging.config
 import asyncio
-import crowlib
+import logging.config
 import os
 import sys
 
@@ -23,6 +18,8 @@ from prompt_toolkit.layout.screen import Char
 from prompt_toolkit.styles import Style
 from prompt_toolkit.widgets import TextArea
 from prompt_toolkit.layout.controls import FormattedTextControl
+
+from druid import crowlib
 
 
 # monkey patch to fix https://github.com/monome/druid/issues/8
@@ -98,12 +95,14 @@ output_field = TextArea(style='class:output-field', text=druid_intro
 
 async def shell():
     global crow
-    input_field = TextArea(height=1, prompt='> ', style='class:input-field', multiline=False, wrap_lines=False
-                           )
+    input_field = TextArea(height=1, prompt='> ', style='class:input-field', multiline=False,
+                           wrap_lines=False)
     captures = VSplit([capture1, capture2])
-    container = HSplit([captures, output_field, Window(height=1, char='/', style='class:line', content=FormattedTextControl(text='druid////'), align=WindowAlign.RIGHT
-                                                       ), input_field
-                        ])
+    container = HSplit([captures, output_field,
+                        Window(height=1, char='/', style='class:line',
+                               content=FormattedTextControl(text='druid////'),
+                               align=WindowAlign.RIGHT),
+                        input_field])
 
     def cwrite(xs):
         global crow
@@ -133,7 +132,7 @@ async def shell():
         ('capture-field', '#747369'),
         ('output-field', '#d3d0c8'),
         ('input-field', '#f2f0ec'),
-        ('line',        '#747369'),
+        ('line', '#747369'),
     ])
 
     application = Application(
@@ -188,7 +187,7 @@ def main():
             'detailed': {
                 'class': 'logging.Formatter',
                 'format': '%(asctime)s %(name)-15s %(levelname)-8s'
-                '%(processName)-10s %(message)s'
+                          '%(processName)-10s %(message)s'
             },
         },
         'handlers': {

--- a/upload.py
+++ b/upload.py
@@ -1,11 +1,13 @@
+#!/usr/bin/env python3
+
 import sys
-import crowlib
 import time
+
+from druid import crowlib
 
 
 def myprint(st):
     print(st)
-
 
 def main():
     try:
@@ -27,6 +29,5 @@ def main():
 
     crow.close()
     exit()
-
 
 main()


### PR DESCRIPTION
As prepwork for publishing to pypi and to make it clearer/simpler to install and use.

Also fixed a bunch of PEP8/linting issues.
I only fixed the simple/non-invasive ones though, will have a look at the rest later.

How to use after these changes (see readme for more instructions):
```bash
$ pip install --user .
Obtaining file:///home/simon/src/monome/druid
Collecting prompt-toolkit>=2.0.10 (from monome-druid==0.1)
  Using cached https://files.pythonhosted.org/packages/87/61/2dfea88583d5454e3a64f9308a686071d58d59a55db638268a6413e1eb6d/prompt_toolkit-2.0.10-py3-none-any.whl
Collecting pyserial>=3.4 (from monome-druid==0.1)
  Using cached https://files.pythonhosted.org/packages/0d/e4/2a744dd9e3be04a0c0907414e2a01a7c88bb3915cbe3c8cc06e209f59c30/pyserial-3.4-py2.py3-none-any.whl
Collecting wcwidth (from prompt-toolkit>=2.0.10->monome-druid==0.1)
  Using cached https://files.pythonhosted.org/packages/7e/9f/526a6947247599b084ee5232e4f9190a38f398d7300d866af3ab571a5bfe/wcwidth-0.1.7-py2.py3-none-any.whl
Collecting six>=1.9.0 (from prompt-toolkit>=2.0.10->monome-druid==0.1)
  Using cached https://files.pythonhosted.org/packages/73/fb/00a976f728d0d1fecfe898238ce23f502a721c0ac0ecfedb80e0d88c64e9/six-1.12.0-py2.py3-none-any.whl
Installing collected packages: wcwidth, six, prompt-toolkit, pyserial, monome-druid
  Running setup.py develop for monome-druid
Successfully installed monome-druid prompt-toolkit-2.0.10 pyserial-3.4 six-1.12.0 wcwidth-0.1.7
$ druid
```

/cc @csboling