### PR TITLE
for discussion: travis build w/ pyinstaller for self-contained deployments

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,55 @@
+os:
+  - windows
+  - linux
+  - osx
+language: shell
+deploy:
+  api_key: see https://docs.travis-ci.com/user/encryption-keys/
+  provider: releases
+  skip_cleanup: true
+  on:
+    tags: true
+
+matrix:
+  include:
+    - name: 'windows python setup'
+      os: windows
+      env: PATH=/c/Python37:/c/Python37/Scripts:$PATH
+      before_install:
+        - choco install python
+      install:
+        - pip install pyinstaller
+        - pip install .
+      script:
+        - pyinstaller -n druid src/druid/main.py
+        - dir ./dist/druid/druid.exe
+        - zip -r druid.zip ./dist/druid
+      deploy:
+        file: druid.zip
+
+    - name: 'linux python setup'
+      os: linux
+      language: python
+      install:
+        - pip3 install pyinstaller
+        - pip3 install .
+      script:
+        - pyinstaller -n druid src/druid/main.py
+        - ls ./dist/druid/druid
+        - tar czvf druid.tar.gz ./dist/druid
+      deploy:
+        file: druid.tar.gz
+
+    - name: 'osx python setup'
+      os: osx
+      before_install:
+        - brew upgrade python
+      install:
+        - pip3 install pyinstaller
+        - pip3 install .
+      script:
+        - pyinstaller -n druid src/druid/main.py
+        - ls ./dist/druid/druid
+        - tar czvf druid.tar.gz ./dist/druid
+      deploy:
+        file: druid.tar.gz


### PR DESCRIPTION
I figure this kind of deployment might be an easier/more familiar alternative to setting up a Python environment, but it might be overkill. Happy to discuss this more in chat.

I was able to get this to [build](https://travis-ci.org/csboling/druid/builds/595451706) on Windows, Linux, and OSX, using [Pyinstaller](https://pythonhosted.org/PyInstaller/index.html) as an automated way to bundle Python apps. This works by packaging up everything imported by a script and adding an appropriate `libpython` runtime shared library + a binary that wraps the entrypoint script.

This is not currently going to build on this branch for a couple of reasons:
* It relies on the project structure in https://github.com/monome/druid/pull/25
* I added a deploy step which is untested, and would require adding a github oauth token

Notes:
* I have tested that the resulting binary works for talking to crow on Windows, but not other platforms.
* There is a `--onefile` option on pyinstaller. This is a simpler deployment but I like that the default build includes all the Python source right there with the program. I reckon in any case it needs to include the GPL, which it doesn't look like pyinstaller found by default.
* It [sounded](https://github.com/monome/druid/pull/23#issuecomment-539664451) like Circle or Github Actions is preferred due to timeouts/other issues with Travis? Looks like Circle [requires a Performance Plan](https://circleci.com/build-on-windows/) for Windows builds. I can give Github Actions a whirl too, that is probably easier to set up now that I've worked out some of the kinks with this.