### PR TITLE
Linting fixes pt1

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 from setuptools import setup, find_namespace_packages
 
 # Read the contents of the readme to publish it to PyPI


### PR DESCRIPTION
Fixed a bunch of linting issues and cleaned up the code a bit.

Pylint is now slightly happier:
```
$ pylint src/druid/repl.py
************* Module repl
src/druid/repl.py:42:0: R0912: Too many branches (13/12) (too-many-branches)
src/druid/repl.py:112:0: C0116: Missing function or method docstring (missing-function-docstring)
src/druid/repl.py:113:4: W0603: Using the global statement (global-statement)
src/druid/repl.py:116:8: W0603: Using the global statement (global-statement)
src/druid/repl.py:119:8: W0702: No exception type(s) specified (bare-except)
src/druid/repl.py:122:15: W0613: Unused argument 'buff' (unused-argument)
src/druid/repl.py:153:4: W0612: Unused variable 'result' (unused-variable)
src/druid/repl.py:160:0: C0116: Missing function or method docstring (missing-function-docstring)
src/druid/repl.py:163:0: C0116: Missing function or method docstring (missing-function-docstring)
src/druid/repl.py:164:4: W0603: Using the global statement (global-statement)
src/druid/repl.py:171:0: C0116: Missing function or method docstring (missing-function-docstring)
src/druid/repl.py:172:4: W0603: Using the global statement (global-statement)
src/druid/repl.py:181:8: W0702: No exception type(s) specified (bare-except)
src/druid/repl.py:187:0: C0116: Missing function or method docstring (missing-function-docstring)
src/druid/repl.py:216:4: W0603: Using the global statement (global-statement)

------------------------------------------------------------------
Your code has been rated at 8.89/10 (previous run: 8.74/10, +0.15)
```