### PR TITLE
Change druid to a regular package

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-from setuptools import setup, find_namespace_packages
+from setuptools import setup, find_packages
 
 # Read the contents of the readme to publish it to PyPI
 with open("README.md") as readme:
@@ -18,7 +18,7 @@ setup(
         "License :: OSI Approved :: GNU General Public License v3 (GPLv3)",
         "Operating System :: OS Independent",
     ],
-    packages=find_namespace_packages("src"),
+    packages=find_packages("src"),
     package_dir={"": "src"},
     include_package_data=True,
     python_requires=">=3.5",


### PR DESCRIPTION
Instead of an implicit namespace package
This way we don't depend on Python3's implicit namespace packages which needs a newer setuptools to work, reducing our installation dependencies.

Fixes #39 