### PR TITLE
ensure crlf line endings to prevent upload crashes

### DIFF
--- a/src/druid/crowlib.py
+++ b/src/druid/crowlib.py
@@ -35,7 +35,8 @@ def writelines(writer, file):
     with open(file) as d:
         lua = d.readlines()
         for line in lua:
-            writer(line.encode())  # convert text to bytes
+            # add crlf and convert text to bytes
+            writer((line.rstrip() + '\r\n').encode())
             time.sleep(0.002)  # fix os x crash?
 
 def upload(writer, printer, file):


### PR DESCRIPTION
Since crow expects CRLF line endings (I am not exactly sure what it is causes problems with LF-only line endings), line endings need to be adjusted when uploading file contents. Sending line endings as-is on Linux and Mac would typically only send `\n`, causing upload failures / hangs / other odd states. This patch corrects line endings by using `rstrip` to remove trailing whitespace and then adding `\r\n` to each line sent during upload.

This explains why the patch https://github.com/monome/crow/pull/232 improves upload stability a lot on Windows, but uploads were still failing for me on Mac - on Windows the line endings are already CRLF. In combination with https://github.com/monome/crow/pull/232 I believe this patch resolves a lot of upload issues, possibly including https://github.com/monome/druid/issues/44 and https://github.com/monome/druid/issues/47.