### PR TITLE
boot without connection & only print disconnected once

### DIFF
--- a/src/druid/repl.py
+++ b/src/druid/repl.py
@@ -108,6 +108,7 @@ container = HSplit([
     input_field])
 
 crow = None
+isConnected = False
 
 async def shell():
     global crow
@@ -162,11 +163,15 @@ def myprint(st):
 
 def crowreconnect():
     global crow
+    global isConnected
     try:
         crow = crowlib.connect()
-        myprint(" <online!>\n")
+        myprint(" <crow connected>\n")
+        isConnected = True
     except ValueError:
-        myprint(" <lost connection>\n")
+        if isConnected == True:
+            myprint(" <lost connection>\n")
+            isConnected = False
 
 async def printer():
     global crow
@@ -213,15 +218,13 @@ def main(script=None):
         },
     })
 
-    global crow
-    try:
-        crow = crowlib.connect()
-    except ValueError as err:
-        print(err)
-        sys.exit(1)
+    crowreconnect()
 
     # run script passed from command line
     if script:
+        if isConnected == False:
+            print("no crow device found. exiting.")
+            sys.exit(1)
         crowlib.execute(crow.write, myprint, script)
 
     loop = asyncio.get_event_loop()

--- a/src/druid/repl.py
+++ b/src/druid/repl.py
@@ -108,7 +108,7 @@ container = HSplit([
     input_field])
 
 crow = None
-isConnected = False
+is_connected = False
 
 async def shell():
     global crow
@@ -163,15 +163,15 @@ def myprint(st):
 
 def crowreconnect():
     global crow
-    global isConnected
+    global is_connected
     try:
         crow = crowlib.connect()
         myprint(" <crow connected>\n")
-        isConnected = True
+        is_connected = True
     except ValueError:
-        if isConnected == True:
+        if is_connected == True:
             myprint(" <lost connection>\n")
-            isConnected = False
+            is_connected = False
 
 async def printer():
     global crow
@@ -222,7 +222,7 @@ def main(script=None):
 
     # run script passed from command line
     if script:
-        if isConnected == False:
+        if is_connected == False:
             print("no crow device found. exiting.")
             sys.exit(1)
         crowlib.execute(crow.write, myprint, script)


### PR DESCRIPTION
fixes #43 
fixes #14 

Track whether a connection is currently active. Only print connect/disconnect on the state change.
On boot, run the 'reconnect' routine, which is essentially just connect that doesn't quit.

NB: I made the CLI options `sys.exit(1)` if no crow is found on boot because they would otherwise just load into the REPL if no device was found which seems incorrect behaviour for a CLI tool. Instead it returns with an errorcode and tells the user there's no crow detected.