### PR TITLE
Add version info to druid package and use it for CLI version output

### DIFF
--- a/.git_archival.txt
+++ b/.git_archival.txt
@@ -1,0 +1,1 @@
+ref-names: $Format:%D$

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+.git_archival.txt  export-subst

--- a/.gitignore
+++ b/.gitignore
@@ -54,5 +54,6 @@ dkms.conf
 build/
 dist/
 __pycache__/
+.eggs
 *.log
 *~

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,6 @@ with open("README.md") as readme:
 
 setup(
     name="monome-druid",
-    version="0.1.1",
     description="Terminal interface for crow",
     long_description=long_description,
     long_description_content_type="text/markdown",
@@ -21,11 +20,18 @@ setup(
     packages=find_packages("src"),
     package_dir={"": "src"},
     include_package_data=True,
+    use_scm_version=True,
     python_requires=">=3.5",
+    setup_requires=[
+        "setuptools_scm",
+        "setuptools_scm_git_archive",
+    ],
     install_requires=[
         "Click>=7.0",
         "prompt-toolkit>=2.0.10",
         "pyserial>=3.4",
+        "setuptools_scm",
+        "setuptools_scm_git_archive",
     ],
     extras_require={
         "test": [

--- a/src/druid/__init__.py
+++ b/src/druid/__init__.py
@@ -1,0 +1,4 @@
+import pkg_resources
+
+from setuptools_scm import get_version
+__version__ = get_version()

--- a/src/druid/cli.py
+++ b/src/druid/cli.py
@@ -5,12 +5,12 @@ import time
 
 import click
 
-from druid import crowlib
+from druid import __version__, crowlib
 from druid import repl as druid_repl
 
 @click.group(invoke_without_command=True)
 @click.pass_context
-@click.version_option()
+@click.version_option(__version__)
 def cli(ctx):
     """ Terminal interface for crow """
     if ctx.invoked_subcommand is None:


### PR DESCRIPTION
This uses https://pypi.org/project/setuptools-scm/ + https://pypi.org/project/setuptools-scm-git-archive/ which is a bit "magic", but from my testing this is the only way to get the version automatically with the following criteria:
- The only action necessary to update the version is `git tag`
- Release archives from GitHub should work and show the correct version
- During development it should be clear that a "development version" is being used. Ideally the shorthash + something like `dev` should be shown

Some output examples:
```
$ druid --version          
druid, version 0.1.2.dev17+g971de94
$ git tag -a 0.1.3 -m "thisisatest"
$ druid --version
druid, version 0.1.3
$ echo "foo" > test.txt
$ git add test.txt
$ druid --version
druid, version 0.1.4.dev0+g07eb4c8.d20191021
```

And when making a release archive (which is what GitHub does):
```
$ git tag -a 0.1.3 -m "thisisatest" 
$ git archive add-version-info | gzip > test.tgz
$ tar -axf test.tgz .git_archival.txt -O       
ref-names: HEAD -> add-version-info, tag: 0.1.3, origin/add-version-info
```
And when installing from this archive
```
$ pip install test.tgz
...
$ druid --version
druid, version 0.1.3
```

@csboling what do you think?

Fixes #29 