### PR TITLE
decrease serial timeout & increase reconnect poll

### DIFF
--- a/src/druid/crowlib.py
+++ b/src/druid/crowlib.py
@@ -18,7 +18,7 @@ def connect():
         logger.error("crow not found, exit")
         raise ValueError("can't find crow device")
     try:
-        return serial.Serial(port, 115200, timeout=0.1)
+        return serial.Serial(port, 115200, timeout=0.01)
     except serial.SerialException as e:
         logger.error("could not open comport {}".format(port), e)
         raise ValueError("can't open serial port")

--- a/src/druid/repl.py
+++ b/src/druid/repl.py
@@ -179,7 +179,7 @@ async def printer():
                 for line in lines:
                     crowparser(line)
         except:
-            sleeptime = 1.0
+            sleeptime = 0.1
             crowreconnect()
         await asyncio.sleep(sleeptime)
 


### PR DESCRIPTION
Fixes the sluggishness of the interface! The issue was how we were polling the `serial.read()` where it would *always* wait for the timeout because we asked for "lots of data", and this would fail to release the asyncio thread.

Fixed by reducing the timeout to 10ms in crowlib.py (was 100ms, causing the 10fps). Feels super snappy now. Input polls are more much more snappy!

Reduced the reconnect rate so druid will auto-connect much faster in case of a pulled cable. This really relies on #49 as otherwise the console fills up fast! Tested on Linux as has no effect on CPU usage when polling for the serial port this fast. Main benefit here is it reduces the delay we have to set on crow before sending a startup message.