### PR TITLE
hack to handle 64byte length lines

### DIFF
--- a/src/druid/crowlib.py
+++ b/src/druid/crowlib.py
@@ -35,9 +35,8 @@ def writelines(writer, file):
     with open(file) as d:
         lua = d.readlines()
         for line in lua:
-            # add crlf and convert text to bytes
-            writer((line.rstrip() + '\r\n').encode())
-            time.sleep(0.002)  # fix os x crash?
+            writer(line.encode())
+            time.sleep(0.001)
 
 def upload(writer, printer, file):
     printer(" uploading "+file+"\n\r")

--- a/src/druid/repl.py
+++ b/src/druid/repl.py
@@ -116,7 +116,7 @@ async def shell():
     def cwrite(xs):
         global crow
         try:
-            if len(xs) == 64:
+            if len(xs)%64 == 0:
                 # Hack to handle osx/win serial port crash
                 xs = xs + ('\n').encode('ascii')
             crow.write(xs)

--- a/src/druid/repl.py
+++ b/src/druid/repl.py
@@ -116,6 +116,9 @@ async def shell():
     def cwrite(xs):
         global crow
         try:
+            if len(xs) == 64:
+                # Hack to handle osx/win serial port crash
+                xs = xs + ('\n').encode('ascii')
             crow.write(xs)
         except:
             crowreconnect()


### PR DESCRIPTION
Turns out the line-ending issue was potentially a red-herring.

This PR removes the forced line-ending encoding as crow should handle either line-endings gracefully.

This does however introduce a gross hack to solve a problem where transmissions of exactly 64bytes would cause crow to stop receiving further data. This solution adds an additonal newline character which crow discards anyway, and remains active. Confusingly this hack is ony needed on windows & osx (not linux).

64bytes is the size of the USB-buffer endpoints on crow. See the following files in the crow project:
crow/submodules/STM32_Cube_F7/Middlewares/ST/STM32_USB_Device_Library/Core/Inc/usbd_def.h @114-115
crow/submodules/STM32_Cube_F7/Middlewares/ST/STM32_USB_Device_Library/Class/CDC/Inc/usbd_cdc.h @58

Tested on lin/win/osx with a number of scripts using both `r` and `u`.