### PR TITLE
fix shutdown exceptions (?) by not waiting for canceled task

### DIFF
--- a/src/druid/repl.py
+++ b/src/druid/repl.py
@@ -238,7 +238,7 @@ def main(script=None):
         background_task = asyncio.gather(printer(), return_exceptions=True)
         loop.run_until_complete(shell())
         background_task.cancel()
-        loop.run_until_complete(background_task)
 
-    crow.close()
+    if is_connected:
+        crow.close()
     sys.exit()


### PR DESCRIPTION
Just doesn't `run_until_complete` the background task after it has been cancelled, since I think this is all the CancelledError means. @simonvanderveldt this feels almost too easy to be the "right" way to fix #12? Works on Windows and OSX, no hanging shell, no lingering Python processes.

The `if is_connected` check is just to prevent a traceback if you quit out of druid without having connected a device, because in that case the `crow` global is `None`.