### PR TITLE
add sleep after ^^p  request to ensure data is valid & ready

### DIFF
--- a/src/druid/cli.py
+++ b/src/druid/cli.py
@@ -28,6 +28,7 @@ def download():
         sys.exit(1)
 
     crow.write(bytes("^^p", "utf-8"))
+    time.sleep(0.3) # wait for print to complete
     click.echo(crow.read(1000000).decode())
     crow.close()
 
@@ -48,10 +49,10 @@ def upload(filename):
         sys.exit(1)
 
     crowlib.upload(crow.write, myprint, filename)
-    click.echo(crow.read(1000000).decode())
-    click.echo("File uploaded")
-    time.sleep(0.5) # wait for new script to be ready
+    click.echo(crow.read(1000000).decode()) # receive errors
+    time.sleep(0.3) # wait for new script to be ready
     crow.write(bytes("^^p", "utf-8"))
+    time.sleep(0.3) # wait for print to complete
     click.echo(crow.read(1000000).decode())
     crow.close()
 


### PR DESCRIPTION
Fixes issue where after either upload or download the `^^print` request would not reliably work due to the buffer being incomplete.

This was likely introduced / exacerbated when the serial object's timeout was reduced to 0.01seconds (from 0.1s).

@csboling I think this should fix this issue: `UnicodeDecodeError: 'utf-8' codec can't decode byte 0xe3 in position 31: invalid continuation byte` if you could test?