### PR TITLE
Fix version info for releases

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -30,6 +30,7 @@ setup(
         "Click>=7.0",
         "prompt-toolkit>=2.0.10",
         "pyserial>=3.4",
+        "setuptools",
         "setuptools_scm",
         "setuptools_scm_git_archive",
     ],

--- a/src/druid/__init__.py
+++ b/src/druid/__init__.py
@@ -1,4 +1,9 @@
 import pkg_resources
 
 from setuptools_scm import get_version
-__version__ = get_version()
+
+try:
+    __version__ = get_version()
+except LookupError:
+    from pkg_resources import get_distribution
+    __version__ = get_distribution("monome-druid").version


### PR DESCRIPTION
Apparently `setuptools_scm` doesn't work for releases (sdist or wheels), not entirely sure why yet, but for now falling back to just getting the version from the installed distribution, which should be good enough for regular usage.

We still keep the dev versions when someone is working on the code this way.