### PR TITLE
readme: Upgrading setuptools should no longer be necessary

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,8 +15,6 @@ Note: you might need to use `python` and `pip` instead of `python3` and `pip3` d
 
 Install and run:
 ```bash
-# Ensure setuptools is up to date
-pip3 install --upgrade setuptools
 # Install druid
 pip3 install monome-druid
 # Run druid :)


### PR DESCRIPTION
Upgrading setuptools should no longer be necessary in most/all situations now that #36 has been merged.

[edit] Or do we simply want to remove this from the readme as a whole and link to the docs on the monome site instead?