### PR TITLE
constrain prompt-toolkit to < 3.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ setup(
     ],
     install_requires=[
         "Click>=7.0",
-        "prompt-toolkit>=2.0.10",
+        "prompt-toolkit>=2.0.10,<3.0",
         "pyserial>=3.4",
         "setuptools",
         "setuptools_scm",


### PR DESCRIPTION
Fixes #64 

prompt-toolkit 3.0.0 [released](https://pypi.org/project/prompt-toolkit/3.0.0/) a few days ago, which is API-incompatible with prompt-toolkit 2.0.0. This breaks new druid installs because it attempts to satisfy the constraint `prompt-toolkit>=2.0.10` with v3.0.0. This patch adds a constraint to require `>=2.0.10,<3.0` as a quick fix until we can update to the new version.