### PR TITLE
always add EOF newline when writing file

### DIFF
--- a/src/druid/crowlib.py
+++ b/src/druid/crowlib.py
@@ -37,6 +37,8 @@ def writelines(writer, file):
         for line in lua:
             writer(line.encode())
             time.sleep(0.001)
+        # in case of missing newline at EOF
+        writer(b'\r\n')
 
 def upload(writer, printer, file):
     printer(" uploading "+file+"\n\r")


### PR DESCRIPTION
Fixes #63 

Results in writing an extra newline if the file contains one, but this should be fine. It does appear I need to clear the user script if one has already been uploaded without a newline.