### PR TITLE
add option to override internal repl theme

### DIFF
--- a/src/druid/cli.py
+++ b/src/druid/cli.py
@@ -46,6 +46,8 @@ def upload(filename):
 
 @cli.command()
 @click.argument("filename", type=click.Path(exists=True), required=False)
-def repl(filename):
+@click.option("--theme/--no-theme", default=True, show_default=True,
+              help="Whether to use the internal color theme.")
+def repl(filename, theme):
     """ Start interactive terminal """
-    druid_repl.main(filename)
+    druid_repl.main(filename, theme)

--- a/src/druid/repl.py
+++ b/src/druid/repl.py
@@ -50,7 +50,7 @@ druid_help = """
 last_script = ''
 
 class DruidUi:
-    def __init__(self):
+    def __init__(self, use_theme):
         self.statusbar = Window(
             height=1,
             char='/',
@@ -81,14 +81,18 @@ class DruidUi:
         def quit_druid(event):
             event.app.exit()
 
-        self.style = Style([
-            ('capture-field', '#747369'),
-            ('output-field', '#d3d0c8'),
-            ('input-field', '#f2f0ec'),
-            ('line', '#747369'),
-            ('scrollbar.background', 'bg:#000000'),
-            ('scrollbar.button', 'bg:#747369'),
-        ])
+        if use_theme:
+            self.style = Style([
+                ('capture-field', '#747369'),
+                ('output-field', '#d3d0c8'),
+                ('input-field', '#f2f0ec'),
+                ('line', '#747369'),
+                ('scrollbar.background', 'bg:#000000'),
+                ('scrollbar.button', 'bg:#747369'),
+            ])
+        else:
+            self.style = Style([])
+
         self.layout = Layout(self.container)
 
         self.app = Application(
@@ -337,9 +341,9 @@ class DruidRepl(UiPage):
 
 
 class Druid:
-    def __init__(self, crow):
+    def __init__(self, crow, use_theme):
         self.crow = crow
-        self.ui = DruidUi()
+        self.ui = DruidUi(use_theme)
 
         self.ui.add_page('repl', DruidRepl(ui=self.ui, crow=crow))
         self.ui.set_page('repl')
@@ -388,7 +392,7 @@ log_config = {
     },
 }
 
-def main(script=None):
+def main(script=None, use_theme=True):
     try:
         logging.config.dictConfig(log_config)
     except ValueError:
@@ -398,7 +402,7 @@ def main(script=None):
     use_asyncio_event_loop()
     with patch_stdout():
         with Crow() as crow:
-            shell = Druid(crow)
+            shell = Druid(crow, use_theme)
             crow.reconnect(err_event=True)
             background_task = asyncio.gather(
                 shell.background(),


### PR DESCRIPTION
Addresses #70 by adding an option to avoid using the internal repl theme colors, meaning the druid repl will inherit the user's specified terminal theme colors. Option needs to be passed to `repl` command:

```
druid repl --no-theme
```

![image](https://user-images.githubusercontent.com/3504098/122833823-99717900-d2bb-11eb-8652-9b1753ed77a7.png)

![image](https://user-images.githubusercontent.com/3504098/122833958-c756bd80-d2bb-11eb-9b2d-0863c7e1197a.png)