### PR TITLE
fix serial port detection

### DIFF
--- a/src/druid/crow.py
+++ b/src/druid/crow.py
@@ -10,10 +10,11 @@ from druid.exceptions import DeviceNotFoundError
 
 logger = logging.getLogger(__name__)
 
-def find_serial_port():
+def find_serial_port(hwid):
     for portinfo in serial.tools.list_ports.comports():
-        if "crow: telephone line" in portinfo.product:
-            return portinfo
+        if hwid in portinfo.hwid:
+            if "crow: telephone line" in portinfo.product:
+                return portinfo
     raise DeviceNotFoundError(f"can't find crow device")
 
 class Crow:
@@ -23,7 +24,7 @@ class Crow:
         self.event_handlers = {}
 
     def find_device(self):
-        portinfo = find_serial_port()
+        portinfo = find_serial_port('USB VID:PID=0483:5740')
         try:
             return serial.Serial(
                 portinfo.device,


### PR DESCRIPTION
1.1.0 would not connect to my crow.

i can't explain why, but if we don't first match on the `hwid` the `for portinfo` line loops infinitely, trying to process the same device (which for me is not the correct device, hence never connecting).

the benefit to this PR is that it matches on the PID/VID as well as the known crow manufacturer-string.

this is tested on an Ubuntu VM, so testing on a mac & windows would be great too.

still, it's a hotfix as the current druid release is broken in pip (at least if you have more than 1 serial device attached).