### PR TITLE
Fix windows connection issue to be more picky

### DIFF
--- a/src/druid/crow.py
+++ b/src/druid/crow.py
@@ -13,10 +13,10 @@ logger = logging.getLogger(__name__)
 
 def find_serial_port(hwid):
     for portinfo in serial.tools.list_ports.comports():
-        if os.name == "nt": # windows doesn't know anything about the port
-            return portinfo
-        elif hwid in portinfo.hwid: # more precise detection for linux/macos
-            if "crow: telephone line" in portinfo.product:
+        if hwid in portinfo.hwid: # must match VID:PID pair (STM32 CDC Device)
+            if os.name == "nt": # windows doesn't know the name of the device
+                return portinfo
+            if "crow: telephone line" in portinfo.product: # more precise detection for linux/macos
                 return portinfo
     raise DeviceNotFoundError(f"can't find crow device")
 


### PR DESCRIPTION
Returning windows to 1.0 connection style where it would match VID:PID pair. maintains improved connection logic for Linux / Mac OS (mfg string) and ignores this extra test on windows (which doesn't have access to mfg string).