### PR TITLE
Disable mouse support to restore ability to select text

### DIFF
--- a/src/druid/repl.py
+++ b/src/druid/repl.py
@@ -100,7 +100,7 @@ class DruidUi:
             layout=self.layout,
             key_bindings=self.key_bindings,
             style=self.style,
-            mouse_support=True,
+            mouse_support=False,
             full_screen=True,
         )
 


### PR DESCRIPTION
Fixes #20, but disables the ability to scroll back up through the output with the mouse.

I personally need to select and copy error messages more than I need to scroll back up through the output.

Problem originates in `prompt-toolkit`. See https://github.com/prompt-toolkit/ptpython/issues/329 for more info. 

